### PR TITLE
chore: replace is-number&clone module

### DIFF
--- a/lib/EleForm.vue
+++ b/lib/EleForm.vue
@@ -111,13 +111,12 @@
 
 <script>
 import responsiveMixin from './mixins/responsiveMixin'
-import { isUnDef, is, castArray, isEmpty } from './tools/utils'
+import { isUnDef, is, castArray, isEmpty, isNumber } from './tools/utils'
 import { throttle } from 'throttle-debounce'
 import localeMixin from './mixins/locale'
 import { t } from './locale'
 import { loadMockJs } from './tools/mock'
-const isNumber = require('is-number')
-const cloneDeep = require('clone')
+import cloneDeep from 'lodash.clonedeep'
 
 export default {
   name: 'EleForm',

--- a/lib/EleFormDialog.vue
+++ b/lib/EleFormDialog.vue
@@ -83,7 +83,7 @@
 </template>
 
 <script>
-const cloneDeep = require('clone')
+import cloneDeep from 'lodash.clonedeep'
 
 export default {
   inheritAttrs: false,

--- a/lib/EleFormDrawer.vue
+++ b/lib/EleFormDrawer.vue
@@ -79,7 +79,7 @@
 </template>
 
 <script>
-const cloneDeep = require('clone')
+import cloneDeep from 'lodash.clonedeep'
 
 export default {
   inheritAttrs: false,

--- a/lib/mixins/attrsMixin.js
+++ b/lib/mixins/attrsMixin.js
@@ -1,5 +1,5 @@
 // 专门为了获取 attrs
-const cloneDeep = require('clone')
+import cloneDeep from 'lodash.clonedeep'
 export default {
   computed: {
     // 获取组件名: 去除EleForm, 并将组件转为 kebab-case

--- a/lib/tools/utils.js
+++ b/lib/tools/utils.js
@@ -13,6 +13,11 @@ export function isFunction(val) {
   return typeof val === 'function'
 }
 
+// 判断是否为数字
+export function isNumber(val) {
+  return is(val, 'Number')
+}
+
 // 判断类型
 export function is(val, type) {
   const typeArr = Array.isArray(type) ? type : [type]

--- a/package.json
+++ b/package.json
@@ -30,9 +30,8 @@
   ],
   "types": "./types/index.d.ts",
   "dependencies": {
-    "clone": "^2.1.2",
     "dayjs": "^1.8.31",
-    "is-number": "^7.0.0",
+    "lodash.clonedeep": "^4.5.0",
     "throttle-debounce": "^2.2.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2777,11 +2777,6 @@ clone@^1.0.2:
   resolved "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-clone@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
-
 coa@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz#43f6c21151b4ef2bf57187db0d73de229e3e7ec3"
@@ -6396,6 +6391,11 @@ lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
+
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
 lodash.defaultsdeep@^4.6.1:
   version "4.6.1"


### PR DESCRIPTION
替换  is-number 和 clone 模块
- 采用 `is(val, 'Number')` 替换 is-number
- 采用 `lodash.clonedeep` 替换 clone

更多的是移除 require 的引用形式，采用es6 import，提高打包构建 vuepress 等场景的兼容性

替换前
```bash
 File                            Size                  Gzipped

  dist/vue-ele-form.umd.min.js    178.45 KiB            55.15 KiB
  dist/vue-ele-form.umd.js        534.50 KiB            114.35 KiB
  dist/vue-ele-form.common.js     534.02 KiB            114.19 KiB
```

替换后
```bash
  File                            Size                  Gzipped

  dist/vue-ele-form.umd.min.js    162.86 KiB            50.55 KiB
  dist/vue-ele-form.umd.js        517.51 KiB            109.63 KiB
  dist/vue-ele-form.common.js     517.03 KiB            109.46 KiB
```
