### PR TITLE
fix: 修复多选可搜索时搜索不存在的数据后，下拉列表消失

### DIFF
--- a/lib/components/EleFormSelect.vue
+++ b/lib/components/EleFormSelect.vue
@@ -6,7 +6,7 @@
     v-bind="attrs"
     v-model="newValue"
     :loading="loading"
-    :remote-method="changeOptions"
+    :remote-method="remoteMethod?changeOptions:null"
     v-on="onEvents"
   >
     <template v-for="(render, key) of slots" v-slot:[key]>


### PR DESCRIPTION
问题复现：
https://user-images.githubusercontent.com/49467518/132430980-b364746d-d0f1-423b-ad7e-fe87746b1ecd.mp4
具体原因：
element-ui中`packages/select/src/select.vue`
![image](https://user-images.githubusercontent.com/49467518/132431032-28279358-00ec-4a8c-8bb9-c4eb544cd88d.png)
element选择框组件中有远程搜索方法时不会emit `queryChange` 事件，因此需要判断一下是否有远程属性
